### PR TITLE
Add missing dependency on async-http

### DIFF
--- a/sus-fixtures-async-http.gemspec
+++ b/sus-fixtures-async-http.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 2.7.0"
 	
+	spec.add_dependency "async-http", "~> 0.59"
 	spec.add_dependency "async-io", "~> 1.34"
 	spec.add_dependency "sus", "~> 0.10"
 	spec.add_dependency "sus-fixtures-async", "~> 0.1"


### PR DESCRIPTION
`async-http` is used on runtime, so I think it should be added as a dependency.

The CI didn't catch this because `async-http` was brought in by `async-rest` which came from `covered`. But `covered` is just a development dependency, so `async-http` should still be missing here.

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
