### PR TITLE
Copy implementation from falcon test suite which allows for SSL.

### DIFF
--- a/test/sus/fixtures/async/http/server_context.rb
+++ b/test/sus/fixtures/async/http/server_context.rb
@@ -22,6 +22,10 @@ describe Sus::Fixtures::Async::HTTP::ServerContext do
 		expect(bound_url).to be =~ %r{http://127.0.0.1}
 	end
 	
+	it 'has a server' do
+		expect(server).to be_a(::Async::HTTP::Server)
+	end
+	
 	with '#client_endpoint' do
 		it 'is suitable as an HTTP endpoint' do
 			expect(client_endpoint).not.to be_nil


### PR DESCRIPTION
Introduce `make_client_endpoint` and `make_server_endpoint` which allow setting SSL contexts.

This was originally implemented in Falcon's test suite.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
