### PR TITLE
Use wait_all to wait for accepting task termination.

### DIFF
--- a/lib/sus/fixtures/async/http/server_context.rb
+++ b/lib/sus/fixtures/async/http/server_context.rb
@@ -185,7 +185,7 @@ module Sus::Fixtures
 					::Async::Task.current.with_timeout(1) do
 						@client&.close
 						@server_task&.stop
-						@server_task&.wait
+						@server_task&.wait_all
 						@bound_endpoint&.close
 					end
 					

--- a/sus-fixtures-async-http.gemspec
+++ b/sus-fixtures-async-http.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.2"
 	
+	spec.add_dependency "async", "~> 2.36"
 	spec.add_dependency "async-http", "~> 0.54"
 	spec.add_dependency "sus", "~> 0.31"
 	spec.add_dependency "sus-fixtures-async", "~> 0.1"


### PR DESCRIPTION
Since reverting <https://github.com/socketry/async-http/pull/217> we need a better strategy for waiting on the accepting tasks.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
